### PR TITLE
Fixed api vscale response with 201 code

### DIFF
--- a/client.go
+++ b/client.go
@@ -112,7 +112,7 @@ func (client *WebClient) ExecuteRequest(method, url string, body []byte, object 
 		return res, errors.New("Not successful status code")
 	}
 
-	if object != nil && res.StatusCode == 200 {
+	if object != nil && (res.StatusCode == 200 || res.StatusCode == 201) {
 		err := json.NewDecoder(reader).Decode(object)
 
 		// EOF means empty response body, this error is not needed


### PR DESCRIPTION
Vscale api changed recently. API started to response with 201 status code for created objects. Thats why go-vscale wan't able to parse data into structs.